### PR TITLE
Fix the bug: Chrome extension fails to work on specific video

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,6 +1,12 @@
-chrome.tabs.onUpdated.addListener((tabId, tab) => {
-  if (tab.url && tab.url.includes("youtube.com/watch")) {
-    const queryParameters = tab.url.split("?")[1];
+/*
+GPT-4: This code will listen for both chrome.tabs.onUpdated and chrome.tabs.onActivated events. When a tab is updated, it will check if the update is complete before sending the message. When a tab is activated, it will use chrome.tabs.get to retrieve the current tab information and send the message accordingly.
+
+This should ensure that the message is being sent to contentScript.js when the URL is updated, and also when you switch between different tabs.
+*/
+
+const sendMessageToContentScript = (tabId, url) => {
+  if (url && url.includes("youtube.com/watch")) {
+    const queryParameters = url.split("?")[1];
     const urlParameters = new URLSearchParams(queryParameters);
 
     chrome.tabs.sendMessage(tabId, {
@@ -8,4 +14,16 @@ chrome.tabs.onUpdated.addListener((tabId, tab) => {
       videoId: urlParameters.get("v"),
     });
   }
+};
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (changeInfo.status === 'complete') {
+    sendMessageToContentScript(tabId, tab.url);
+  }
+});
+
+chrome.tabs.onActivated.addListener((activeInfo) => {
+  chrome.tabs.get(activeInfo.tabId, (tab) => {
+    sendMessageToContentScript(activeInfo.tabId, tab.url);
+  });
 });

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "My YT Bookmarks",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Saving timestamps in YT videos",
   "permissions": ["storage", "tabs"],
   "host_permissions": ["https://*.youtube.com/*"],


### PR DESCRIPTION
https://github.com/raman-at-pieces/youtube-bookmarker-finished-code/issues/4

This commit fixes the bug where the Chrome extension did not work for certain video URLs. The solution involves using both chrome.tabs.onUpdated and chrome.tabs.onActivated event listeners in background.js to ensure the content script receives the necessary messages.

- Added chrome.tabs.onActivated event listener with chrome.tabs.get method
- Updated chrome.tabs.onUpdated event listener to check for 'complete' status