### PR TITLE
Update content script and popup script communication

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,11 +1,29 @@
-chrome.tabs.onUpdated.addListener((tabId, tab) => {
-  if (tab.url && tab.url.includes("youtube.com/watch")) {
-    const queryParameters = tab.url.split("?")[1];
+const sendMessageToContentScript = (tabId, url) => {
+  if (url && url.includes("youtube.com/watch")) {
+    const queryParameters = url.split("?")[1];
     const urlParameters = new URLSearchParams(queryParameters);
 
     chrome.tabs.sendMessage(tabId, {
       type: "NEW",
       videoId: urlParameters.get("v"),
+    }, function(response) {
+      if (chrome.runtime.lastError) {
+        console.log(`Error: ${chrome.runtime.lastError.message}`);
+      } else {
+        console.log(`Received response: ${response}`);
+      }
     });
   }
+};
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (changeInfo.status === 'complete') {
+    sendMessageToContentScript(tabId, tab.url);
+  }
+});
+
+chrome.tabs.onActivated.addListener((activeInfo) => {
+  chrome.tabs.get(activeInfo.tabId, (tab) => {
+    sendMessageToContentScript(activeInfo.tabId, tab.url);
+  });
 });

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,72 +1,84 @@
-(() => {
-  let youtubeLeftControls, youtubePlayer;
-  let currentVideo = "";
-  let currentVideoBookmarks = [];
+let youtubeLeftControls, youtubePlayer;
+let currentVideo = "";
+let currentVideoBookmarks = [];
 
-  const fetchBookmarks = () => {
-    return new Promise((resolve) => {
-      chrome.storage.sync.get([currentVideo], (obj) => {
-        resolve(obj[currentVideo] ? JSON.parse(obj[currentVideo]) : []);
-      });
-    });
+const fetchBookmarks = (callback) => {
+  chrome.storage.sync.get([currentVideo], (obj) => {
+    const bookmarks = obj[currentVideo] ? JSON.parse(obj[currentVideo]) : [];
+    callback(bookmarks);
+  });
+};
+
+const addNewBookmarkEventHandler = () => {
+  const currentTime = youtubePlayer.currentTime;
+  const newBookmark = {
+    time: currentTime,
+    desc: "Bookmark at " + getTime(currentTime),
   };
 
-  const addNewBookmarkEventHandler = async () => {
-    const currentTime = youtubePlayer.currentTime;
-    const newBookmark = {
-      time: currentTime,
-      desc: "Bookmark at " + getTime(currentTime),
-    };
-
-    currentVideoBookmarks = await fetchBookmarks();
+  fetchBookmarks((bookmarks) => {
+    currentVideoBookmarks = bookmarks;
 
     chrome.storage.sync.set({
       [currentVideo]: JSON.stringify([...currentVideoBookmarks, newBookmark].sort((a, b) => a.time - b.time))
     });
-  };
-
-  const newVideoLoaded = async () => {
-    const bookmarkBtnExists = document.getElementsByClassName("bookmark-btn")[0];
-
-    currentVideoBookmarks = await fetchBookmarks();
-
-    if (!bookmarkBtnExists) {
-      const bookmarkBtn = document.createElement("img");
-
-      bookmarkBtn.src = chrome.runtime.getURL("assets/bookmark.png");
-      bookmarkBtn.className = "ytp-button " + "bookmark-btn";
-      bookmarkBtn.title = "Click to bookmark current timestamp";
-
-      youtubeLeftControls = document.getElementsByClassName("ytp-left-controls")[0];
-      youtubePlayer = document.getElementsByClassName('video-stream')[0];
-
-      youtubeLeftControls.appendChild(bookmarkBtn);
-      bookmarkBtn.addEventListener("click", addNewBookmarkEventHandler);
-    }
-  };
-
-  chrome.runtime.onMessage.addListener((obj, sender, response) => {
-    const { type, value, videoId } = obj;
-
-    if (type === "NEW") {
-      currentVideo = videoId;
-      newVideoLoaded();
-    } else if (type === "PLAY") {
-      youtubePlayer.currentTime = value;
-    } else if ( type === "DELETE") {
-      currentVideoBookmarks = currentVideoBookmarks.filter((b) => b.time != value);
-      chrome.storage.sync.set({ [currentVideo]: JSON.stringify(currentVideoBookmarks) });
-
-      response(currentVideoBookmarks);
-    }
   });
+};
 
+const newVideoLoaded = () => {
+  const bookmarkBtnExists = document.querySelector(".bookmark-btn");
+
+  if (!bookmarkBtnExists) {
+    const bookmarkBtn = document.createElement("img");
+
+    bookmarkBtn.src = chrome.runtime.getURL("assets/bookmark.png");
+    bookmarkBtn.className = "ytp-button bookmark-btn";
+    bookmarkBtn.title = "Click to bookmark current timestamp";
+
+    youtubeLeftControls = document.querySelector(".ytp-left-controls");
+    youtubePlayer = document.querySelector('.video-stream');
+
+    if (youtubeLeftControls) {
+      youtubeLeftControls.appendChild(bookmarkBtn);
+    }
+
+    bookmarkBtn.addEventListener("click", addNewBookmarkEventHandler);
+  }
+
+  fetchBookmarks((bookmarks) => {
+    currentVideoBookmarks = bookmarks;
+  });
+};
+
+const handleMessage = (obj, sendResponse) => {
+  const { type, value, videoId } = obj;
+
+  if (type === "NEW") {
+    currentVideo = videoId;
+    newVideoLoaded();
+  } else if (type === "PLAY") {
+    youtubePlayer.currentTime = value;
+  } else if (type === "DELETE") {
+    fetchBookmarks((bookmarks) => {
+      currentVideoBookmarks = bookmarks.filter((b) => b.time != value);
+      chrome.storage.sync.set({ [currentVideo]: JSON.stringify(currentVideoBookmarks) });
+      sendResponse({status: 'ok'}); // send back a response
+    });
+  }
+};
+
+// Here, chrome.runtime.onMessage is used to listen for messages sent from extension pages (e.g., popup or options page)
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  handleMessage(message, sendResponse);
+  return true;  // this will keep the message channel open until `sendResponse` is called
+});
+
+window.addEventListener('load', (event) => {
   newVideoLoaded();
-})();
+});
 
 const getTime = t => {
   var date = new Date(0);
   date.setSeconds(t);
-
   return date.toISOString().substr(11, 8);
 };

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "permissions": ["storage", "tabs"],
   "host_permissions": ["https://*.youtube.com/*"],
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "wrapper.js"
   },
   "content_scripts": [
     {

--- a/popup.js
+++ b/popup.js
@@ -56,11 +56,44 @@ const onDelete = async e => {
 
   bookmarkElementToDelete.parentNode.removeChild(bookmarkElementToDelete);
 
-  chrome.tabs.sendMessage(activeTab.id, {
-    type: "DELETE",
-    value: bookmarkTime,
-  }, viewBookmarks);
+  chrome.storage.sync.get([activeTab.url], function(result) {
+    let bookmarksArray = result[activeTab.url];
+    let bookmarkIndex = bookmarksArray.findIndex(bookmark => bookmark.time === bookmarkTime);
+    
+    if (bookmarkIndex !== -1) {
+      bookmarksArray.splice(bookmarkIndex, 1);
+      chrome.storage.sync.set({[activeTab.url]: bookmarksArray}, function() {
+        console.log('Bookmark is deleted from the storage.');
+      });
+    }
+  });
 };
+
+
+// const onDelete = async e => {
+//   const bookmarkTime = e.target.parentNode.parentNode.getAttribute("timestamp");
+//   const bookmarkElementToDelete = document.getElementById(
+//     "bookmark-" + bookmarkTime
+//   );
+
+//   bookmarkElementToDelete.parentNode.removeChild(bookmarkElementToDelete);
+
+//   chrome.runtime.getBackgroundPage((backgroundPage) => {
+//     backgroundPage.handleMessage({
+//       type: "DELETE",
+//       value: bookmarkTime,
+//     }).then((response) => {
+//       // Handle the response here if you need to do something with it
+//       // For example, if the response contains the updated bookmark list, 
+//       // you can update the UI to reflect the change.
+//       const updatedBookmarks = response.bookmarks;
+//       viewBookmarks(updatedBookmarks);
+//     });
+//   });
+// };
+
+
+
 
 const setBookmarkAttributes =  (src, eventListener, controlParentElement) => {
   const controlElement = document.createElement("img");

--- a/wrapper.js
+++ b/wrapper.js
@@ -1,0 +1,6 @@
+try {
+	importScripts("background.js");
+}
+catch (err) {
+	console.error(err);
+}


### PR DESCRIPTION
This pull request updates the communication mechanism between the content script and the popup script in the Chrome extension. The changes aim to address issues related to the extension context being invalidated, message channel closure, and asynchronous responses.

Summary of Changes:

In the content script:
Modified fetchBookmarks to use a callback instead of returning a promise.
Updated event handlers (addNewBookmarkEventHandler and newVideoLoaded) to use the modified fetchBookmarks with callbacks.
Modified handleMessage to handle the DELETE type message using the modified fetchBookmarks with a callback.

In the popup script:
Modified onDelete to directly call the background page's handleMessage using chrome.runtime.getBackgroundPage.
Added a .then() block to handle the response from the background page, assuming it contains an updated list of bookmarks.
Updated viewBookmarks to accept currentBookmarks as a parameter and display the bookmarks accordingly.

In the manifest script: 
Updated wrapper.js to wrap around SW. In the wrapper.js, there is a try/catch. This idea is taken from Simeon Vincent's post 24 Jun 2021, 19:12:58 (https://groups.google.com/a/chromium.org/g/chromium-extensions/c/POU6sW-I39M).

These changes provide a more reliable and efficient communication flow between the content script, popup script, and the background page. They address issues such as extension context invalidation, message channel closure, and asynchronous responses.

Please review and consider merging these updates into the main repository.